### PR TITLE
Process cwd support for Mac, Linux, and Win32

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -212,14 +212,11 @@ public class NuProcessBuilder
     * Set the {@link Path} to which the current working directory (cwd) of the
     * subsequent launch of a {@link NuProcess} will be set when calling the {@link #start()} method.
     *
-    * @param cwd a {@link Path} to use for the process's current working directory
+    * @param cwd a {@link Path} to use for the process's current working directory, or {@code null}
+    *            to disable setting the cwd of subsequently launched proceses
     */
    public void setCwd(Path cwd)
    {
-      if (cwd == null) {
-         throw new IllegalArgumentException("A Path must be specified");
-      }
-
       this.cwd = cwd;
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -16,6 +16,7 @@
 
 package com.zaxxer.nuprocess;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +53,7 @@ public class NuProcessBuilder
 
    private final List<String> command;
    private final TreeMap<String, String> environment;
+   private Path cwd;
    private NuProcessHandler processListener;
 
    static {
@@ -207,6 +209,21 @@ public class NuProcessBuilder
    }
 
    /**
+    * Set the {@link Path} to which the current working directory (cwd) of the
+    * subsequent launch of a {@link NuProcess} will be set when calling the {@link #start()} method.
+    *
+    * @param cwd a {@link Path} to use for the process's current working directory
+    */
+   public void setCwd(Path cwd)
+   {
+      if (cwd == null) {
+         throw new IllegalArgumentException("A Path must be specified");
+      }
+
+      this.cwd = cwd;
+   }
+
+   /**
     * Spawn the child process with the configured commands, environment, and {@link NuProcessHandler}.
     *
     * @return a {@link NuProcess} instance or {@code null} if there is an immediately detectable launch failure
@@ -223,6 +240,6 @@ public class NuProcessBuilder
          env[i++] = entrySet.getKey() + "=" + entrySet.getValue();
       }
 
-      return factory.createProcess(command, env, processListener);
+      return factory.createProcess(command, env, processListener, cwd);
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Future;
@@ -55,7 +56,7 @@ public abstract class BasePosixProcess implements NuProcess
    protected static IEventProcessor<? extends BasePosixProcess>[] processors;
    protected static int processorRoundRobin;
 
-   private static ExecutorService linuxCwdChangeableExecutorService;
+   private static ExecutorService linuxCwdExecutorService;
 
    protected IEventProcessor<? super BasePosixProcess> myProcessor;
    protected volatile NuProcessHandler processHandler;
@@ -93,7 +94,7 @@ public abstract class BasePosixProcess implements NuProcess
    private Pointer posix_spawn_file_actions;
 
    // Launches threads under which changes to cwd do not affect the cwd of the process.
-   public static class LinuxCwdChangeableThreadFactory implements ThreadFactory {
+   public static class LinuxCwdThreadFactory implements ThreadFactory {
       private final AtomicInteger threadCount = new AtomicInteger(0);
 
       @Override
@@ -101,7 +102,11 @@ public abstract class BasePosixProcess implements NuProcess
          Runnable unshareCwdThenSpawn = new Runnable() {
             @Override
             public void run() {
+              // This makes a copy of the process's chroot, cwd, and umask and
+              // allows the thread to change any of those in a way that doesn't
+              // affect the rest of the process.
               int rc = LinuxLibC.unshare(LinuxLibC.CLONE_FS);
+              // If this throws, then it bubbles up to whomever called ExecutorService.submit().
               checkReturnCode(rc, "unshare(CLONE_FS) failed");
               r.run();
             }
@@ -144,12 +149,12 @@ public abstract class BasePosixProcess implements NuProcess
       }
 
       if (IS_LINUX) {
-         linuxCwdChangeableExecutorService = new ThreadPoolExecutor(
+         linuxCwdExecutorService = new ThreadPoolExecutor(
              /* corePoolSize */ numThreads,
              /* maximumPoolSize */ numThreads,
              /* keepAliveTime */ 0L, TimeUnit.MILLISECONDS,
              /* workQueue */ new LinkedBlockingQueue<Runnable>(),
-             /* threadFactory */ new LinuxCwdChangeableThreadFactory(),
+             /* threadFactory */ new LinuxCwdThreadFactory(),
              /* handler */ new ThreadPoolExecutor.DiscardPolicy());
       }
    }
@@ -295,9 +300,9 @@ public abstract class BasePosixProcess implements NuProcess
          StringArray environmentArray = new StringArray(environment);
          if (cwd != null) {
              if (IS_MAC) {
-                 rc = spawnWithCwdSetViaPthreadChdir(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray, cwd);
+                 rc = spawnOsxWithCwd(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray, cwd);
              } else if (IS_LINUX) {
-                 rc = spawnWithCwdSetViaLinuxCwdChangeableExecutorService(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray, cwd);
+                 rc = spawnLinuxWithCwd(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray, cwd);
              } else {
                  throw new RuntimeException("Platform does not support per-thread cwd override");
              }
@@ -369,7 +374,7 @@ public abstract class BasePosixProcess implements NuProcess
       return this;
    }
 
-   private int spawnWithCwdSetViaPthreadChdir(
+   private int spawnOsxWithCwd(
       IntByReference restrict_pid,
       String restrict_path,
       Pointer file_actions,
@@ -395,7 +400,7 @@ public abstract class BasePosixProcess implements NuProcess
      }
    }
 
-   private int spawnWithCwdSetViaLinuxCwdChangeableExecutorService(
+   private int spawnLinuxWithCwd(
       final IntByReference restrict_pid,
       final String restrict_path,
       final Pointer file_actions,
@@ -404,12 +409,14 @@ public abstract class BasePosixProcess implements NuProcess
       final Pointer /*String[]*/envp,
       final Path cwd)
    {
-     Future<Integer> setCwdThenSpawnFuture = linuxCwdChangeableExecutorService.submit(
+     Future<Integer> setCwdThenSpawnFuture = linuxCwdExecutorService.submit(
          new Callable<Integer>() {
            @Override
            public Integer call() {
                // Set cwd in this thread, which has its cwd state disassociated from the rest of the process.
                int rc = LibC.chdir(cwd.toAbsolutePath().toString());
+               // If this throws, it'll be wrapped in an ExecutionException and re-thrown on the thread
+               // which calls Future.get().
                checkReturnCode(rc, "chdir() failed");
                // posix_spawnp() will inherit the cwd of this thread.
                //
@@ -420,7 +427,14 @@ public abstract class BasePosixProcess implements NuProcess
          });
      try {
        return setCwdThenSpawnFuture.get();
-     } catch (Exception e) {
+     } catch (ExecutionException e) {
+       Throwable cause = e.getCause();
+       if (cause instanceof RuntimeException) {
+         throw (RuntimeException) cause;
+       } else {
+         throw new RuntimeException(cause);
+       }
+     } catch (InterruptedException e) {
        throw new RuntimeException(e);
      }
    }

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -25,13 +25,21 @@ import com.zaxxer.nuprocess.NuProcess;
 import com.zaxxer.nuprocess.NuProcessHandler;
 
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -46,6 +54,8 @@ public abstract class BasePosixProcess implements NuProcess
 
    protected static IEventProcessor<? extends BasePosixProcess>[] processors;
    protected static int processorRoundRobin;
+
+   private static ExecutorService linuxCwdChangeableExecutorService;
 
    protected IEventProcessor<? super BasePosixProcess> myProcessor;
    protected volatile NuProcessHandler processHandler;
@@ -82,6 +92,26 @@ public abstract class BasePosixProcess implements NuProcess
 
    private Pointer posix_spawn_file_actions;
 
+   // Launches threads under which changes to cwd do not affect the cwd of the process.
+   public static class LinuxCwdChangeableThreadFactory implements ThreadFactory {
+      private final AtomicInteger threadCount = new AtomicInteger(0);
+
+      @Override
+      public Thread newThread(final Runnable r) {
+         Runnable unshareCwdThenSpawn = new Runnable() {
+            @Override
+            public void run() {
+              int rc = LinuxLibC.unshare(LinuxLibC.CLONE_FS);
+              checkReturnCode(rc, "unshare(CLONE_FS) failed");
+              r.run();
+            }
+         };
+         Thread newThread = Executors.defaultThreadFactory().newThread(unshareCwdThenSpawn);
+         newThread.setName(String.format("NuProcessLinuxCwdChangeable-%d", threadCount.incrementAndGet()));
+         return newThread;
+      }
+   }
+
    static {
       IS_SOFTEXIT_DETECTION = Boolean.valueOf(System.getProperty("com.zaxxer.nuprocess.softExitDetection", "true"));
 
@@ -111,6 +141,16 @@ public abstract class BasePosixProcess implements NuProcess
                }
             }
          }));
+      }
+
+      if (IS_LINUX) {
+         linuxCwdChangeableExecutorService = new ThreadPoolExecutor(
+             /* corePoolSize */ numThreads,
+             /* maximumPoolSize */ numThreads,
+             /* keepAliveTime */ 0L, TimeUnit.MILLISECONDS,
+             /* workQueue */ new LinkedBlockingQueue<Runnable>(),
+             /* threadFactory */ new LinuxCwdChangeableThreadFactory(),
+             /* handler */ new ThreadPoolExecutor.DiscardPolicy());
       }
    }
 
@@ -219,7 +259,7 @@ public abstract class BasePosixProcess implements NuProcess
    //                             Public methods
    // ************************************************************************
 
-   public NuProcess start(List<String> command, String[] environment)
+   public NuProcess start(List<String> command, String[] environment, Path cwd)
    {
       callPreStart();
       
@@ -251,7 +291,19 @@ public abstract class BasePosixProcess implements NuProcess
          LibC.posix_spawnattr_setflags(posix_spawnattr, flags);
 
          IntByReference restrict_pid = new IntByReference();
-         rc = LibC.posix_spawnp(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, new StringArray(commands), new StringArray(environment));
+         StringArray commandsArray = new StringArray(commands);
+         StringArray environmentArray = new StringArray(environment);
+         if (cwd != null) {
+             if (IS_MAC) {
+                 rc = spawnWithCwdSetViaPthreadChdir(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray, cwd);
+             } else if (IS_LINUX) {
+                 rc = spawnWithCwdSetViaLinuxCwdChangeableExecutorService(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray, cwd);
+             } else {
+                 throw new RuntimeException("Platform does not support per-thread cwd override");
+             }
+         } else {
+             rc = LibC.posix_spawnp(restrict_pid, commands[0], posix_spawn_file_actions, posix_spawnattr, commandsArray, environmentArray);
+         }
 
          pid = restrict_pid.getValue();
 
@@ -315,6 +367,62 @@ public abstract class BasePosixProcess implements NuProcess
       }
 
       return this;
+   }
+
+   private int spawnWithCwdSetViaPthreadChdir(
+      IntByReference restrict_pid,
+      String restrict_path,
+      Pointer file_actions,
+      Pointer /*const posix_spawnattr_t*/restrict_attrp,
+      StringArray /*String[]*/argv,
+      Pointer /*String[]*/envp,
+      Path cwd)
+   {
+     int cwdBufSize = 1024;
+     long peer = Native.malloc(cwdBufSize);
+     Pointer oldCwd = new Pointer(peer);
+     LibC.getcwd(oldCwd, cwdBufSize);
+     String newCwd = cwd.toAbsolutePath().toString();
+     int rc = LibC.SYSCALL.syscall(LibC.SYSCALL.SYS___pthread_chdir, newCwd);
+     checkReturnCode(rc, "syscall(SYS__pthread_chdir) failed to set current directory");
+
+     try {
+       return LibC.posix_spawnp(restrict_pid, restrict_path, file_actions, restrict_attrp, argv, envp);
+     } finally {
+       rc = LibC.SYSCALL.syscall(LibC.SYSCALL.SYS___pthread_chdir, oldCwd);
+       Native.free(Pointer.nativeValue(oldCwd));
+       checkReturnCode(rc, "syscall(SYS__pthread_chdir) failed to restore current directory");
+     }
+   }
+
+   private int spawnWithCwdSetViaLinuxCwdChangeableExecutorService(
+      final IntByReference restrict_pid,
+      final String restrict_path,
+      final Pointer file_actions,
+      final Pointer /*const posix_spawnattr_t*/restrict_attrp,
+      final StringArray /*String[]*/argv,
+      final Pointer /*String[]*/envp,
+      final Path cwd)
+   {
+     Future<Integer> setCwdThenSpawnFuture = linuxCwdChangeableExecutorService.submit(
+         new Callable<Integer>() {
+           @Override
+           public Integer call() {
+               // Set cwd in this thread, which has its cwd state disassociated from the rest of the process.
+               int rc = LibC.chdir(cwd.toAbsolutePath().toString());
+               checkReturnCode(rc, "chdir() failed");
+               // posix_spawnp() will inherit the cwd of this thread.
+               //
+               // We don't bother restoring cwd, since this thread will either be destroyed or re-used
+               // later by the same executor, which will then chdir anyway.
+               return LibC.posix_spawnp(restrict_pid, restrict_path, file_actions, restrict_attrp, argv, envp);
+           }
+         });
+     try {
+       return setCwdThenSpawnFuture.get();
+     } catch (Exception e) {
+       throw new RuntimeException(e);
+     }
    }
 
    public int getPid()
@@ -732,7 +840,7 @@ public abstract class BasePosixProcess implements NuProcess
       }
    }
 
-   private void checkReturnCode(int rc, String failureMessage)
+   private static void checkReturnCode(int rc, String failureMessage)
    {
       if (rc != 0) {
          throw new RuntimeException(failureMessage + ", return code: " + rc + ", last error: " + Native.getLastError());

--- a/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
@@ -17,8 +17,10 @@
 package com.zaxxer.nuprocess.internal;
 
 import com.sun.jna.Callback;
+import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.StringArray;
 import com.sun.jna.ptr.IntByReference;
@@ -75,6 +77,20 @@ public class LibC
                                          Pointer /*const posix_spawnattr_t*/restrict_attrp, StringArray /*String[]*/argv, Pointer /*String[]*/envp);
 
    public static native Pointer signal(int signal, Pointer func);
+
+   public static native int chdir(String path);
+
+   public static native String getcwd(Pointer buf, int size);
+
+   // from /usr/include/sys/syscall.h
+   // We can't use JNA direct mapping for syscall(), since it takes varargs.
+   public interface SyscallLibrary extends Library {
+      public static final int SYS___pthread_chdir = 348;
+      int syscall(int syscall_number, Object... args);
+   }
+
+   public static SyscallLibrary SYSCALL = (SyscallLibrary) Native.loadLibrary(
+      Platform.C_LIBRARY_NAME, SyscallLibrary.class);
 
    public static final int F_GETFL = 3;
    public static final int F_SETFL = 4;

--- a/src/main/java/com/zaxxer/nuprocess/internal/LinuxLibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LinuxLibC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Brett Wooldridge
+ * Copyright (C) 2015 Ben Hamilton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package com.zaxxer.nuprocess;
+package com.zaxxer.nuprocess.internal;
 
-import java.util.List;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
 
-import java.nio.file.Path;
-
-/**
- * <b>This is an internal class.</b>  Instances of this interface create and start processes
- * in a platform-specific fashion.  
- *
- * @author Brett Wooldridge
- */
-public interface NuProcessFactory
+public class LinuxLibC
 {
-   NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd);
+   static {
+      Native.register(Platform.C_LIBRARY_NAME);
+   }
+
+   // from /usr/include/sched.h
+   public static native int unshare(int flags);
+
+   // from /usr/include/bits/sched.h
+   public static final int CLONE_FS = 0x00000200; /* Share or unshare cwd between threads / processes */
 }

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinProcessFactory.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.nuprocess.linux;
 
+import java.nio.file.Path;
+
 import java.util.List;
 
 import com.zaxxer.nuprocess.NuProcess;
@@ -31,11 +33,11 @@ public class LinProcessFactory implements NuProcessFactory
 {
    /** {@inheritDoc} */
    @Override
-   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener)
+   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
    {
       LinuxProcess process = new LinuxProcess(processListener);
       synchronized (LinProcessFactory.class) {
-         process.start(commands, env);
+         process.start(commands, env, cwd);
       }
       return process;
    }

--- a/src/main/java/com/zaxxer/nuprocess/osx/OsxProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/OsxProcessFactory.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.nuprocess.osx;
 
+import java.nio.file.Path;
+
 import java.util.List;
 
 import com.zaxxer.nuprocess.NuProcess;
@@ -26,10 +28,10 @@ public class OsxProcessFactory implements NuProcessFactory
 {
    /** {@inheritDoc} */
    @Override
-   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener)
+   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
    {
       OsxProcess process = new OsxProcess(processListener);
-      process.start(commands, env);
+      process.start(commands, env, cwd);
       return process;
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
@@ -47,7 +47,7 @@ public class NuKernel32
 
    public static native boolean CreateProcessW(WString lpApplicationName, char[] lpCommandLine, WinBase.SECURITY_ATTRIBUTES lpProcessAttributes,
                                                WinBase.SECURITY_ATTRIBUTES lpThreadAttributes, boolean bInheritHandles, DWORD dwCreationFlags,
-                                               Pointer lpEnvironment, String lpCurrentDirectory, WinBase.STARTUPINFO lpStartupInfo,
+                                               Pointer lpEnvironment, char[] lpCurrentDirectory, WinBase.STARTUPINFO lpStartupInfo,
                                                WinBase.PROCESS_INFORMATION lpProcessInformation);
 
    public static native boolean TerminateProcess(HANDLE hProcess, int exitCode);

--- a/src/main/java/com/zaxxer/nuprocess/windows/WinProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WinProcessFactory.java
@@ -19,6 +19,8 @@
  */
 package com.zaxxer.nuprocess.windows;
 
+import java.nio.file.Path;
+
 import java.util.List;
 
 import com.zaxxer.nuprocess.NuProcess;
@@ -34,10 +36,10 @@ public class WinProcessFactory implements NuProcessFactory
 {
    /** {@inheritDoc} */
    @Override
-   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener)
+   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
    {
       WindowsProcess process = new WindowsProcess(processListener);
-      process.start(commands, env);
+      process.start(commands, env, cwd);
       return process;
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -16,6 +16,7 @@
 
 package com.zaxxer.nuprocess.windows;
 
+import java.nio.file.Path;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -194,7 +195,7 @@ public final class WindowsProcess implements NuProcess
    {
       return !pendingWrites.isEmpty();
    }
-   
+
    /** {@inheritDoc} */
    @Override
    public void destroy(boolean force)
@@ -220,10 +221,10 @@ public final class WindowsProcess implements NuProcess
    //                          Package-scoped methods
    // ************************************************************************
 
-   NuProcess start(List<String> commands, String[] environment)
+   NuProcess start(List<String> commands, String[] environment, Path cwd)
    {
       callPreStart();
-      
+
       try {
          createPipes();
 
@@ -242,8 +243,14 @@ public final class WindowsProcess implements NuProcess
          processInfo = new PROCESS_INFORMATION();
 
          DWORD dwCreationFlags = new DWORD(WinNT.CREATE_NO_WINDOW | WinNT.CREATE_UNICODE_ENVIRONMENT | WinNT.CREATE_SUSPENDED);
+         char[] cwdChars;
+         if (cwd != null) {
+           cwdChars = Native.toCharArray(cwd.toAbsolutePath().toString());
+         } else {
+           cwdChars = null;
+         }
          if (!NuKernel32.CreateProcessW(null, getCommandLine(commands), null /*lpProcessAttributes*/, null /*lpThreadAttributes*/, true /*bInheritHandles*/,
-                                        dwCreationFlags, env, null /*lpCurrentDirectory*/, startupInfo, processInfo)) {
+                                        dwCreationFlags, env, cwdChars, startupInfo, processInfo)) {
             int lastError = Native.getLastError();
             throw new RuntimeException("CreateProcessW() failed, error: " + lastError);
          }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -243,12 +243,7 @@ public final class WindowsProcess implements NuProcess
          processInfo = new PROCESS_INFORMATION();
 
          DWORD dwCreationFlags = new DWORD(WinNT.CREATE_NO_WINDOW | WinNT.CREATE_UNICODE_ENVIRONMENT | WinNT.CREATE_SUSPENDED);
-         char[] cwdChars;
-         if (cwd != null) {
-           cwdChars = Native.toCharArray(cwd.toAbsolutePath().toString());
-         } else {
-           cwdChars = null;
-         }
+         char[] cwdChars = (cwd != null) ? Native.toCharArray(cwd.toAbsolutePath().toString()) : null;
          if (!NuKernel32.CreateProcessW(null, getCommandLine(commands), null /*lpProcessAttributes*/, null /*lpThreadAttributes*/, true /*bInheritHandles*/,
                                         dwCreationFlags, env, cwdChars, startupInfo, processInfo)) {
             int lastError = Native.getLastError();


### PR DESCRIPTION
This is stacked on top of https://github.com/brettwooldridge/NuProcess/pull/30 , so I hope I'm creating it correctly.

This implements setting the current working directory for a launched process on OS X, Linux, and Win32. Since calling `chdir()` affects every thread in the process, we have to use different strategies on each OS.
1. Win32: Pretty easy: `CreateProcessW()` already supports passing in the current directory as a `U+0000`-terminated array.
2. OS X: Also fairly easy: `syscall(SYS___pthread_chdir, cwd)` allows us to temporarily override the thread's current directory before we spawn the process, then we restore it.
3. Linux: This one is more difficult. We create a thread pool from which we use the `unshare(CLONE_FS)` API to disassociate the calling thread's cwd from the rest of the process. Then we call `chdir()` from that thread before we spawn the process.

I included a unit test. I made sure everything works on Windows, Mac, and Linux.

This does depend on the Java 7 `Path` API. If we need this to work on Java 6, we'll need to use the crummy `File` or just a `String`.
